### PR TITLE
CMake IMPORTED_LINK_DEPENDENT_LIBRARIES not on configuration basis

### DIFF
--- a/src/gui/Qt5GuiConfigExtras.cmake.in
+++ b/src/gui/Qt5GuiConfigExtras.cmake.in
@@ -173,11 +173,7 @@ _qt5gui_find_extra_libs(OPENGL \"$$CMAKE_OPENGL_LIBS\" \"$$CMAKE_OPENGL_LIBDIR\"
 
 set(Qt5Gui_OPENGL_IMPLEMENTATION $$CMAKE_QT_OPENGL_IMPLEMENTATION)
 
-get_target_property(_configs Qt5::Gui IMPORTED_CONFIGURATIONS)
-foreach(_config ${_configs})
-    set_property(TARGET Qt5::Gui APPEND PROPERTY
-        IMPORTED_LINK_DEPENDENT_LIBRARIES_${_config}
-        ${Qt5Gui_EGL_LIBRARIES} ${Qt5Gui_OPENGL_LIBRARIES}
-    )
-endforeach()
-unset(_configs)
+set_property(TARGET Qt5::Gui APPEND PROPERTY
+    IMPORTED_LINK_DEPENDENT_LIBRARIES
+    ${Qt5Gui_EGL_LIBRARIES} ${Qt5Gui_OPENGL_LIBRARIES}
+)


### PR DESCRIPTION
We don't need the CMake IMPORTED_LINK_DEPENDENT_LIBRARIES on a
configuration basis as they point to other CMake imported targets
(Qt5::Gui_EGL and Qt5::Gui_GLESv2).