### PR TITLE
Fix printing page margins wrong values on windows

### DIFF
--- a/src/printsupport/dialogs/qpagesetupdialog_win.cpp
+++ b/src/printsupport/dialogs/qpagesetupdialog_win.cpp
@@ -130,11 +130,11 @@ int QPageSetupDialog::exec()
     if (result) {
         engine->setGlobalDevMode(psd.hDevNames, psd.hDevMode);
         // You must divide margins by 'multiplier' before assign it to QMarginsF object,
-        // because float is to short to store not divided rtMargin
-        const QMarginsF margins(psd.rtMargin.left   / multiplier,
-                                psd.rtMargin.top    / multiplier,
-                                psd.rtMargin.right  / multiplier,
-                                psd.rtMargin.bottom / multiplier);
+        // because qreal can be float and to short to store not divided rtMargin (long)
+        const QMarginsF margins(qreal(double(psd.rtMargin.left)   / multiplier),
+                                qreal(double(psd.rtMargin.top)    / multiplier),
+                                qreal(double(psd.rtMargin.right)  / multiplier),
+                                qreal(double(psd.rtMargin.bottom) / multiplier) );
         d->printer->setPageMargins(margins, layout.units());
 
         // copy from our temp DEVMODE struct

--- a/src/printsupport/dialogs/qpagesetupdialog_win.cpp
+++ b/src/printsupport/dialogs/qpagesetupdialog_win.cpp
@@ -129,8 +129,13 @@ int QPageSetupDialog::exec()
     QDialog::setVisible(false);
     if (result) {
         engine->setGlobalDevMode(psd.hDevNames, psd.hDevMode);
-        const QMarginsF margins(psd.rtMargin.left, psd.rtMargin.top, psd.rtMargin.right, psd.rtMargin.bottom);
-        d->printer->setPageMargins(margins / multiplier, layout.units());
+        // You must divide margins by 'multiplier' before assign it to QMarginsF object,
+        // because float is to short to store not divided rtMargin
+        const QMarginsF margins(psd.rtMargin.left   / multiplier,
+                                psd.rtMargin.top    / multiplier,
+                                psd.rtMargin.right  / multiplier,
+                                psd.rtMargin.bottom / multiplier);
+        d->printer->setPageMargins(margins, layout.units());
 
         // copy from our temp DEVMODE struct
         if (!engine->globalDevMode() && hDevMode) {


### PR DESCRIPTION
There is an error. The page margins have wrong values because of float overrange. Huge value is assigned to float and then divided by a 'multiplier'. The solution is first to divide and rhen assigne it to float.

This error was resolved in 5.3.0 or 5.3.1 version (don't remember) and then the 5.3.2 introduced it again!