### PR TITLE
Fix for platform socklen_t on other C libraries than glibc.

### DIFF
--- a/mkspecs/linux-g++/qplatformdefs.h
+++ b/mkspecs/linux-g++/qplatformdefs.h
@@ -78,10 +78,10 @@
 
 #undef QT_SOCKLEN_T
 
-#if defined(__GLIBC__) && (__GLIBC__ >= 2)
-#define QT_SOCKLEN_T            socklen_t
-#else
+#if defined(__GLIBC__) && (__GLIBC__ < 2)
 #define QT_SOCKLEN_T            int
+#else
+#define QT_SOCKLEN_T            socklen_t
 #endif
 
 #if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500)


### PR DESCRIPTION
Would be awesome to get this merged for 5.5.1.