### PR TITLE
QtWidgets: Remove QGraphicsEffect double scaling (on hiDpi)

### DIFF
--- a/src/widgets/kernel/qwidget.cpp
+++ b/src/widgets/kernel/qwidget.cpp
@@ -5898,9 +5898,7 @@ QPixmap QWidgetEffectSourcePrivate::pixmap(Qt::CoordinateSystem system, QPoint *
 
     pixmapOffset -= effectRect.topLeft();
 
-    const qreal dpr = context->painter->device()->devicePixelRatio();
-    QPixmap pixmap(effectRect.size() * dpr);
-    pixmap.setDevicePixelRatio(dpr);
+    QPixmap pixmap(effectRect.size());
 
     pixmap.fill(Qt::transparent);
     m_widget->render(&pixmap, pixmapOffset, QRegion(), QWidget::DrawChildren);


### PR DESCRIPTION
Device pixel ratio is already considered in effect source widget.
Multiplying pixmap by ratio doubles effect source.