### PR TITLE
qeglpbuffer_p.h - move EGL/egl.h as the last include

### DIFF
--- a/src/platformsupport/eglconvenience/qeglpbuffer_p.h
+++ b/src/platformsupport/eglconvenience/qeglpbuffer_p.h
@@ -45,9 +45,9 @@
 // We mean it.
 //
 
-#include <EGL/egl.h>
 #include <qpa/qplatformoffscreensurface.h>
 #include <QtPlatformSupport/private/qeglplatformcontext_p.h>
+#include <EGL/egl.h>
 
 QT_BEGIN_NAMESPACE
 


### PR DESCRIPTION
Otherwise compilation on Freescale leads to:
    ../../include/QtCore/../../../git/src/corelib/io/qtextstream.h:46:2: error: #error qtextstream.h must be included before any header file that defines Status

    |  #error qtextstream.h must be included before any header file that defines Status

    |   ^

Source: https://community.freescale.com/thread/379855

**Notice:** the problem persists in all versions of Qt, not only 5.6