### PR TITLE
Applying widget toolTipDuration to items

### DIFF
--- a/src/widgets/itemviews/qabstractitemdelegate.cpp
+++ b/src/widgets/itemviews/qabstractitemdelegate.cpp
@@ -386,7 +386,7 @@ bool QAbstractItemDelegate::helpEvent(QHelpEvent *event,
         QHelpEvent *he = static_cast<QHelpEvent*>(event);
         QVariant tooltip = index.data(Qt::ToolTipRole);
         if (tooltip.canConvert<QString>()) {
-            QToolTip::showText(he->globalPos(), tooltip.toString(), view);
+            QToolTip::showText(he->globalPos(), tooltip.toString(), view, QRect(), view->toolTipDuration());
             return true;
         }
         break;}


### PR DESCRIPTION
If you set toolTipDuration to QListView widget,
the toolTip at the blank area is displayed exactly for the specified duration and then disappear.
But toolTip at item is displayed forever. It should be displayed for the same duration.
This pull request fixes that problem by applying the widget toopTipDuration to item toolTip.